### PR TITLE
add namespace

### DIFF
--- a/include/tms_if_for_opera/zx200_change_pose_action_server.hpp
+++ b/include/tms_if_for_opera/zx200_change_pose_action_server.hpp
@@ -60,6 +60,7 @@ private:
   rclcpp_action::Server<Zx200ChangePose>::SharedPtr action_server_;
   rclcpp::Node::SharedPtr move_group_node_;
   std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group_;
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface::Options> move_group_options_;
   rclcpp::executors::SingleThreadedExecutor executor_;
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
   // std::vector<double> current_joint_values_;

--- a/include/tms_if_for_opera/zx200_excavate_simple_action_server.hpp
+++ b/include/tms_if_for_opera/zx200_excavate_simple_action_server.hpp
@@ -60,6 +60,7 @@ private:
   rclcpp_action::Server<Zx200ExcavateSimple>::SharedPtr action_server_;
   rclcpp::Node::SharedPtr move_group_node_;
   std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group_;
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface::Options> move_group_options_;
   rclcpp::executors::SingleThreadedExecutor executor_;
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
   // std::vector<double> current_joint_values_;

--- a/include/tms_if_for_opera/zx200_release_simple_action_server.hpp
+++ b/include/tms_if_for_opera/zx200_release_simple_action_server.hpp
@@ -62,6 +62,7 @@ private:
   rclcpp_action::Server<Zx200ReleaseSimple>::SharedPtr action_server_;
   rclcpp::Node::SharedPtr move_group_node_;
   std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group_;
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface::Options> move_group_options_;
   rclcpp::executors::SingleThreadedExecutor executor_;
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
   // std::vector<double> current_joint_values_;

--- a/launch/tms_if_for_opera.launch.py
+++ b/launch/tms_if_for_opera.launch.py
@@ -40,6 +40,7 @@ def generate_launch_description():
     zx200_change_pose_action_server_node = Node(
         package='tms_if_for_opera',
         executable='zx200_change_pose_action_server',
+        namespace='zx200',
         parameters=[
             {'robot_description': robot_description_content},
             {'planning_group': LaunchConfiguration('planning_group')},
@@ -49,6 +50,7 @@ def generate_launch_description():
     zx200_excavate_simple_action_server_node = Node(
         package='tms_if_for_opera',
         executable='zx200_excavate_simple_action_server',
+        namespace='zx200',
         parameters=[
             {'robot_description': robot_description_content},
             {'planning_group': LaunchConfiguration('planning_group')},
@@ -58,6 +60,7 @@ def generate_launch_description():
     zx200_release_simple_action_server_node = Node(
         package='tms_if_for_opera',
         executable='zx200_release_simple_action_server',
+        namespace='zx200',
         parameters=[
             {'robot_description': robot_description_content},
             {'planning_group': LaunchConfiguration('planning_group')},

--- a/src/zx200_change_pose_action_server.cpp
+++ b/src/zx200_change_pose_action_server.cpp
@@ -46,7 +46,9 @@ Zx200ChangePoseActionServer::Zx200ChangePoseActionServer(const rclcpp::NodeOptio
   executor_.add_node(move_group_node_);
   std::thread([this]() { executor_.spin(); }).detach();
 
-  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, planning_group_);
+  // move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, planning_group_);
+  move_group_options_ = std::make_shared<moveit::planning_interface::MoveGroupInterface::Options>(planning_group_, "robot_description", "/zx200");
+  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, *move_group_options_);
 
   move_group_->setMaxVelocityScalingFactor(1.0);
   move_group_->setMaxAccelerationScalingFactor(1.0);

--- a/src/zx200_excavate_simple_action_server.cpp
+++ b/src/zx200_excavate_simple_action_server.cpp
@@ -46,7 +46,10 @@ Zx200ExcavateSimpleActionServer::Zx200ExcavateSimpleActionServer(const rclcpp::N
   executor_.add_node(move_group_node_);
   std::thread([this]() { executor_.spin(); }).detach();
 
-  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, planning_group_);
+  // move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, planning_group_);
+  move_group_options_ = std::make_shared<moveit::planning_interface::MoveGroupInterface::Options>(planning_group_, "robot_description", "/zx200");
+  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, *move_group_options_);
+  
   // moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
 
   move_group_->setMaxVelocityScalingFactor(1.0);

--- a/src/zx200_release_simple_action_server.cpp
+++ b/src/zx200_release_simple_action_server.cpp
@@ -47,6 +47,9 @@ Zx200ReleaseSimpleActionServer::Zx200ReleaseSimpleActionServer(const rclcpp::Nod
   std::thread([this]() { executor_.spin(); }).detach();
 
   move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, planning_group_);
+  move_group_options_ = std::make_shared<moveit::planning_interface::MoveGroupInterface::Options>(planning_group_, "robot_description", "/zx200");
+  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, *move_group_options_); 
+  
   // moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
 
   move_group_->setMaxVelocityScalingFactor(1.0);


### PR DESCRIPTION
ネームスペースを付与できるよう、修正。
現在はMoveIt!の内部プログラムの関係でzx200_ros2が"zx200"という接頭辞にしか対応できないため、こちらも"zx200"という接頭辞のみに対応。