### PR TITLE
fix: package.xml に不足している <depend> を追加

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,11 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>urdf</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>com3_msgs</depend>
 
   <depend>moveit_common</depend>
   <depend>moveit_ros_planning_interface</depend>


### PR DESCRIPTION
## 背景

`CMakeLists.txt` で `find_package(..., REQUIRED)` を呼んでいるパッケージのうち、以下が `package.xml` の `<depend>` に記載されていませんでした:

- `std_msgs`
- `tf2`
- `tf2_geometry_msgs`
- `nav2_msgs`
- `com3_msgs`

## 再現

`develop/for_develop_ts` をワークスペースに配置して `colcon build` を走らせると、以下のエラーで `tms_if_for_opera` のビルドが失敗します。

```
CMake Error at CMakeLists.txt:55 (find_package):
  By not providing "Findcom3_msgs.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "com3_msgs", but CMake did not find one.
```

## 原因

`<depend>` に記載がないパッケージは `colcon` が依存関係解決の対象にしないため、`tms_if_for_opera` が依存パッケージ（`com3_msgs` など）のビルド完了を待たずに開始され、`find_package` が失敗します。

## 修正内容

`CMakeLists.txt` で `find_package` されている ROS 2 パッケージをすべて `<depend>` に追加しました。

`mongocxx` / `bsoncxx` は `/usr/local` にインストールされる非 ROS 2 の C++ ライブラリのため、`<depend>` 追加対象外としています。

## 動作確認

`ros2_tms_for_construction` の `develop/ts` と組み合わせた Docker ビルド環境で、本修正前はビルド失敗、本修正後は `colcon build --symlink-install` が成功（38 packages finished, 0 failures）することを確認しました。